### PR TITLE
feat: add guardian bus and council report bot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Discord bot credentials
+DISCORD_TOKEN=
+CLIENT_ID=
+GUILD_ID=
+OWNER_ID=
+
+# Channel and webhook IDs
+CHN_COUNCIL=
+WH_LILYBEAR=
+
+# External service endpoints
+MCP_URL=
+NAV_REPOS=MKWorldWide/GameDin, MKWorldWide/Serafina, MKWorldWide/AthenaCore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Large binary assets are tracked via Git LFS
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text
+*.jpeg filter=lfs diff=lfs merge=lfs -text
+*.wav filter=lfs diff=lfs merge=lfs -text
+*.mp3 filter=lfs diff=lfs merge=lfs -text
+*.mp4 filter=lfs diff=lfs merge=lfs -text
+*.fbx filter=lfs diff=lfs merge=lfs -text
+*.prefab filter=lfs diff=lfs merge=lfs -text
+*.unity filter=lfs diff=lfs merge=lfs -text
+*.asset filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -44,4 +44,12 @@ out/
 
 # Dependencies
 node_modules/
-packages/ 
+packages/
+
+# Unity-generated folders
+Library/
+Temp/
+Obj/
+Build/
+Logs/
+UserSettings/

--- a/Assets/GameDinVR/Scripts/GeminiOrb.cs
+++ b/Assets/GameDinVR/Scripts/GeminiOrb.cs
@@ -1,0 +1,19 @@
+using UdonSharp;
+using UnityEngine;
+
+/// <summary>
+/// Simple example orb that rotates at a constant speed.
+/// Demonstrates UdonSharp usage for VRChat worlds.
+/// </summary>
+[UdonBehaviourSyncMode(BehaviourSyncMode.None)]
+public class GeminiOrb : UdonSharpBehaviour
+{
+    // Degrees per second; exposed in Unity inspector for tuning.
+    public float RotationSpeed = 45f;
+
+    private void Update()
+    {
+        // Rotate the orb around its Y axis every frame.
+        transform.Rotate(Vector3.up * (RotationSpeed * Time.deltaTime), Space.Self);
+    }
+}

--- a/Assets/GameDinVR/Scripts/GuardianBase.cs
+++ b/Assets/GameDinVR/Scripts/GuardianBase.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+/// <summary>
+/// Base class for all guardian behaviours. Handles subscription to the ops bus
+/// and basic whisper routing so derived guardians only implement their own logic.
+/// </summary>
+public class GuardianBase : MonoBehaviour {
+    [Header("Identity")]
+    public string GuardianName = "Guardian";
+    public string Role = "Undefined";
+
+    protected virtual void OnEnable(){
+        if (LilybearOpsBus.I != null)
+            LilybearOpsBus.I.OnWhisper += HandleWhisper;
+    }
+
+    protected virtual void OnDisable(){
+        if (LilybearOpsBus.I != null)
+            LilybearOpsBus.I.OnWhisper -= HandleWhisper;
+    }
+
+    /// <summary>
+    /// Called whenever the bus relays a message. Derived classes can override OnMessage
+    /// to react to whispers addressed to them.
+    /// </summary>
+    protected virtual void HandleWhisper(string from, string to, string message){
+        if (to == GuardianName || to == "*") {
+            Debug.Log($"[{GuardianName}] received from {from}: {message}");
+            OnMessage(from, message);
+        }
+    }
+
+    /// <summary>
+    /// Implement guardian-specific logic for incoming whispers.
+    /// </summary>
+    public virtual void OnMessage(string from, string message) {}
+
+    /// <summary>
+    /// Utility method for sending a whisper to another guardian or broadcast.
+    /// </summary>
+    protected void Whisper(string to, string message){
+        LilybearOpsBus.I?.Say(GuardianName, to, message);
+    }
+}

--- a/Assets/GameDinVR/Scripts/Guardians/AthenaGuardian.cs
+++ b/Assets/GameDinVR/Scripts/Guardians/AthenaGuardian.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Athena: strategy & intelligence guardian.
+/// Responds to status requests and can be expanded to run analytics.
+/// </summary>
+public class AthenaGuardian : GuardianBase {
+    void Start(){
+        GuardianName = "Athena";
+        Role = "Strategy & Intelligence";
+    }
+
+    public override void OnMessage(string from, string message){
+        if (message.Contains("status")){
+            Whisper("Lilybear", "Athena: All systems nominal.");
+        }
+    }
+}

--- a/Assets/GameDinVR/Scripts/Guardians/SerafinaGuardian.cs
+++ b/Assets/GameDinVR/Scripts/Guardians/SerafinaGuardian.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Serafina: communications & routing guardian.
+/// This mirrors the Discord bot role inside the VR scene.
+/// </summary>
+public class SerafinaGuardian : GuardianBase {
+    void Start(){
+        GuardianName = "Serafina";
+        Role = "Comms & Routing";
+    }
+
+    public override void OnMessage(string from, string message){
+        if (message.StartsWith("bless")){
+            Whisper("ShadowFlowers", "Please deliver a blessing to the hall.");
+        }
+    }
+}

--- a/Assets/GameDinVR/Scripts/Guardians/ShadowFlowersGuardian.cs
+++ b/Assets/GameDinVR/Scripts/Guardians/ShadowFlowersGuardian.cs
@@ -1,0 +1,22 @@
+using UnityEngine;
+
+/// <summary>
+/// ShadowFlowers: sentiment & rituals guardian.
+/// Displays blessings and ceremonial messages to the scene.
+/// </summary>
+public class ShadowFlowersGuardian : GuardianBase {
+    public TextMesh BlessingText;
+
+    void Start(){
+        GuardianName = "ShadowFlowers";
+        Role = "Sentiment & Rituals";
+    }
+
+    public override void OnMessage(string from, string message){
+        if (message.Contains("blessing")){
+            var line = "\uD83C\uDF38 May your path be protected and your heart be held.";
+            if (BlessingText) BlessingText.text = line;
+            Whisper("Lilybear", "Blessing delivered.");
+        }
+    }
+}

--- a/Assets/GameDinVR/Scripts/LilybearController.cs
+++ b/Assets/GameDinVR/Scripts/LilybearController.cs
@@ -1,0 +1,32 @@
+using UnityEngine;
+
+/// <summary>
+/// Lilybear: voice & operations hub. Routes commands and logs them.
+/// This behaviour can be extended to bridge Discord traffic into the scene
+/// via OSC or other networking later.
+/// </summary>
+public class LilybearController : GuardianBase {
+    [TextArea] public string LastMessage;
+
+    void Start(){
+        GuardianName = "Lilybear";
+        Role = "Voice & Operations";
+    }
+
+    public override void OnMessage(string from, string message){
+        LastMessage = $"{from}: {message}";
+        // Example: commands starting with '/route ' get broadcast to all guardians.
+        if (message.StartsWith("/route ")){
+            var payload = message.Substring(7); // strip '/route '
+            Whisper("*", payload);
+        }
+    }
+
+    /// <summary>
+    /// Manual test hook visible in the Unity inspector.
+    /// </summary>
+    [ContextMenu("Test Whisper")]
+    void TestWhisper(){
+        Whisper("*", "The council is assembled.");
+    }
+}

--- a/Assets/GameDinVR/Scripts/LilybearOpsBus.cs
+++ b/Assets/GameDinVR/Scripts/LilybearOpsBus.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+using System;
+using System.Collections.Generic;
+
+/// <summary>
+/// Simple in-scene event bus so guardians can whisper to each other.
+/// Acts as the nervous system for cross-script communication inside the VRChat scene.
+/// </summary>
+public class LilybearOpsBus : MonoBehaviour {
+    /// Singleton-like access for other components.
+    public static LilybearOpsBus I;
+
+    void Awake(){ I = this; }
+
+    /// Delegate signature for a guardian whisper.
+    public delegate void Whisper(string from, string to, string message);
+    /// Fired whenever any guardian broadcasts via Say().
+    public event Whisper OnWhisper;
+
+    /// <summary>
+    /// Broadcast a message to a specific guardian or '*' for everyone.
+    /// </summary>
+    public void Say(string from, string to, string message){
+        OnWhisper?.Invoke(from, to, message);
+        Debug.Log($"[LilybearBus] {from} → {to}: {message}");
+    }
+}

--- a/Assets/GameDinVR/Scripts/OSC/OSCTextBridge.cs
+++ b/Assets/GameDinVR/Scripts/OSC/OSCTextBridge.cs
@@ -1,0 +1,16 @@
+using UnityEngine;
+
+/// <summary>
+/// Placeholder component for future OSC hook.
+/// External services (e.g., Serafina bot) can set text in-world via OSC.
+/// </summary>
+public class OSCTextBridge : MonoBehaviour {
+    public TextMesh Target;
+
+    /// <summary>
+    /// Set the text of the assigned TextMesh.
+    /// </summary>
+    public void SetText(string s){
+        if (Target) Target.text = s;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A sensory-emotive simulation game where players cultivate a garden reflecting their emotions. Built in Roblox Studio.
 
+## 🔮 VRChat Refactor
+
+The project now includes an experimental Unity scaffold for a future VRChat version. A minimal UdonSharp script (`GeminiOrb.cs`) lives under `Assets/GameDinVR/Scripts`, and `vpm-manifest.json` defines the VRChat Creator Companion dependencies. Backend and Discord bridge work references our [Serafina](https://github.com/mkworldwide/serafina), [shadow-nexus](https://github.com/mkworldwide/shadow-nexus), and [AthenaCore](https://github.com/mkworldwide/athenacore) repositories.
+
+### ShadowFlower Council Proof-of-Concept
+
+Unity now contains a lightweight ops bus and three guardian examples—`Athena`, `Serafina`, and `ShadowFlowers`—under
+`Assets/GameDinVR/Scripts`. Each guardian listens for in‑world whispers routed through `LilybearController`, giving us a
+foundation for VRChat <-> Discord message bridging. A placeholder `OSCTextBridge` is included for future external text updates
+via OSC.
+
+Companion Node scripts in `serafina/src` provide a Discord bot with a nightly "council report" and a `/council report now`
+slash command for manual triggering. Messages in the council channel prefixed with `!` (e.g. `!athena status`) are relayed to
+the VR world via an MCP `/osc` endpoint, letting in‑world guardians react. Environment variables live in `.env.example`.
+
+### VRChat Setup
+
+1. Install the [VRChat Creator Companion](https://vcc.docs.vrchat.com/) and Unity 2022.3 LTS.
+2. Run `git lfs install` to enable Git LFS for large assets.
+3. Open this folder as a project in VCC; dependencies from `vpm-manifest.json` will auto-install.
+4. Load `Assets/GameDinVR` in Unity, add the `GeminiOrb` script to a GameObject, then build and publish a test world.
+
 ## 🌟 Features
 
 - **Emotional Garden System**: Cultivate plants that reflect and respond to your emotional state

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "neurobloom",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "echo \"No tests yet\""
+  },
+  "dependencies": {
+    "cron": "^2.3.1",
+    "discord.js": "^14.14.1",
+    "dotenv": "^16.3.1",
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/serafina/src/nightlyReport.ts
+++ b/serafina/src/nightlyReport.ts
@@ -1,0 +1,82 @@
+import 'dotenv/config';
+import fetch from 'node-fetch';
+import cron from 'cron';
+import { Client, EmbedBuilder, TextChannel } from 'discord.js';
+
+const MCP = process.env.MCP_URL || '';
+const COUNCIL_CH = process.env.CHN_COUNCIL || '';
+const LILY_WEBHOOK = process.env.WH_LILYBEAR || '';
+const GH_REPOS = (process.env.NAV_REPOS || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+async function getMcpStatus(): Promise<string> {
+  try {
+    const r = await fetch(`${MCP}/ask-gemini`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ prompt: 'Summarize system health in one sentence.' }),
+    });
+    const j = await r.json().catch(() => ({ response: '(no data)' }));
+    return j.response || '(no data)';
+  } catch {
+    return '(MCP unreachable)';
+  }
+}
+
+async function getRepoDigest(repo: string): Promise<string> {
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const url = `https://api.github.com/repos/${repo}/commits?since=${encodeURIComponent(since)}&per_page=5`;
+  try {
+    const r = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
+    if (!r.ok) return `• ${repo}: no recent commits`;
+    const commits = (await r.json()) as any[];
+    if (!commits.length) return `• ${repo}: 0 commits in last 24h`;
+    return commits
+      .map(c => `• ${repo}@${(c.sha || '').slice(0, 7)} — ${c.commit.message.split('\n')[0]}`)
+      .join('\n');
+  } catch {
+    return `• ${repo}: (error fetching commits)`;
+  }
+}
+
+export async function runCouncilReport(client: Client): Promise<void> {
+  const mcp = await getMcpStatus();
+  const repoLines = GH_REPOS.length
+    ? (await Promise.all(GH_REPOS.map(getRepoDigest))).join('\n')
+    : '—';
+  const emb = new EmbedBuilder()
+    .setTitle('🌙 Nightly Council Report')
+    .setDescription('Summary of the last 24h across our realm.')
+    .setColor(0x9b59b6)
+    .addFields(
+      { name: 'System Health (MCP)', value: mcp.slice(0, 1024) || '—' },
+      { name: 'Recent Commits', value: repoLines.slice(0, 1024) || '—' },
+    )
+    .setFooter({ text: 'Reported by Lilybear' })
+    .setTimestamp(new Date());
+
+  try {
+    if (LILY_WEBHOOK) {
+      await fetch(LILY_WEBHOOK, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ embeds: [emb.toJSON()] }),
+      });
+    } else {
+      const ch = client.channels.cache.get(COUNCIL_CH) as TextChannel | undefined;
+      await ch?.send({ embeds: [emb] });
+    }
+  } catch (e) {
+    console.error('Nightly report error:', e);
+  }
+}
+
+export function scheduleNightlyCouncilReport(client: Client): void {
+  // 08:00 UTC daily
+  const job = new cron.CronJob('0 8 * * *', async () => {
+    await runCouncilReport(client);
+  }, null, true, 'UTC');
+  job.start();
+}

--- a/serafina/src/router.ts
+++ b/serafina/src/router.ts
@@ -1,0 +1,94 @@
+import 'dotenv/config';
+// Core Discord bot wiring. Bridges slash commands and text whispers to the VR layer.
+// Using explicit intent flags so Discord gives us message content for routing.
+import {
+  Client,
+  GatewayIntentBits,
+  REST,
+  Routes,
+  SlashCommandBuilder,
+  Events,
+} from 'discord.js';
+import fetch from 'node-fetch';
+import { scheduleNightlyCouncilReport, runCouncilReport } from './nightlyReport.js';
+
+const TOKEN = process.env.DISCORD_TOKEN || '';
+const CLIENT_ID = process.env.CLIENT_ID || '';
+const GUILD_ID = process.env.GUILD_ID || '';
+const MCP = process.env.MCP_URL || '';
+const COUNCIL_CH = process.env.CHN_COUNCIL || '';
+
+// Register the slash command on startup.
+// `/council report now` → manually trigger the nightly council report.
+const rest = new REST({ version: '10' }).setToken(TOKEN);
+const commands = [
+  new SlashCommandBuilder()
+    .setName('council')
+    .setDescription('ShadowFlower council utilities')
+    .addSubcommandGroup(group =>
+      group
+        .setName('report')
+        .setDescription('Council reporting utilities')
+        .addSubcommand(sub =>
+          sub
+            .setName('now')
+            .setDescription('Post the nightly council report immediately')
+        )
+    )
+].map(c => c.toJSON());
+
+async function registerCommands() {
+  try {
+    await rest.put(Routes.applicationGuildCommands(CLIENT_ID, GUILD_ID), { body: commands });
+    console.log('Slash commands registered');
+  } catch (err) {
+    console.error('Error registering commands', err);
+  }
+}
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+client.once(Events.ClientReady, () => {
+  console.log(`Logged in as ${client.user?.tag}`);
+  scheduleNightlyCouncilReport(client);
+});
+
+client.on(Events.InteractionCreate, async interaction => {
+  if (!interaction.isChatInputCommand()) return;
+  if (
+    interaction.commandName === 'council' &&
+    interaction.options.getSubcommandGroup() === 'report' &&
+    interaction.options.getSubcommand() === 'now'
+  ) {
+    await interaction.reply({ content: 'Summoning council report…', ephemeral: true });
+    await runCouncilReport(client);
+  }
+});
+
+// Relay text whispers from the council channel into the VR layer via MCP /osc.
+client.on(Events.MessageCreate, async msg => {
+  if (msg.author.bot || msg.channelId !== COUNCIL_CH) return;
+  if (!msg.content.startsWith('!')) return; // `!athena status`
+  const [toRaw, ...rest] = msg.content.slice(1).split(' ');
+  const to = toRaw || '*';
+  const whisper = rest.join(' ').trim();
+  if (!whisper || !MCP) return;
+
+  try {
+    await fetch(`${MCP}/osc`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from: msg.author.username, to, message: whisper }),
+    });
+  } catch (err) {
+    console.error('Failed to relay whisper', err);
+  }
+});
+
+registerCommands().then(() => client.login(TOKEN));

--- a/vpm-manifest.json
+++ b/vpm-manifest.json
@@ -1,0 +1,6 @@
+{
+  "dependencies": {
+    "com.vrchat.worlds": "3.4.2",
+    "com.vrchat.udonsharp": "1.1.1"
+  }
+}


### PR DESCRIPTION
## Summary
- add Lilybear ops bus with sample guardians for Athena, Serafina, ShadowFlowers
- add Serafina discord bot skeleton with nightly council report and slash command
- document council proof-of-concept and provide env template
- relay council channel whispers to VR via MCP and expose `/council report now`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895a909fdc0832583dc4f0eb61e15c4